### PR TITLE
fix(build-order): strip stray contenteditable <br> from resource cells

### DIFF
--- a/src/components/builds/BuildOrderEditor.vue
+++ b/src/components/builds/BuildOrderEditor.vue
@@ -245,6 +245,24 @@ export default {
       return ageImageUrlMap[currentAge] || "";
     }
 
+    // Resource/timing cells are plain-text fields, but they are edited via
+    // contenteditable divs where Chrome leaves a stray "<br>" (and sometimes a
+    // wrapping block) when a cell is cleared. Those builds were persisted with
+    // e.g. stone: "<br>", which then renders as literal text. Strip any markup
+    // from these fields on load so existing builds display correctly.
+    const PLAIN_TEXT_STEP_FIELDS = ["time", "builders", "food", "wood", "gold", "stone"];
+    function sanitizeStepFields(sects) {
+      for (const section of sects) {
+        for (const step of section.steps ?? []) {
+          for (const field of PLAIN_TEXT_STEP_FIELDS) {
+            if (typeof step[field] === "string") {
+              step[field] = step[field].replace(/<[^>]*>/g, "").trim();
+            }
+          }
+        }
+      }
+    }
+
     /**
      * Initialize sections based on props.steps data.
      * If props.steps[0].type is not defined, migrates to a new format.
@@ -263,6 +281,7 @@ export default {
       } else {
         sections.value = JSON.parse(JSON.stringify(props.steps));
       }
+      sanitizeStepFields(sections.value);
     }
 
     return {

--- a/src/components/builds/BuildOrderSectionEditor.vue
+++ b/src/components/builds/BuildOrderSectionEditor.vue
@@ -856,7 +856,13 @@ export default {
     };
 
     const updateStep = (event, index, propertyName) => {
-      const val = event.target.tagName === 'INPUT' ? event.target.value : event.target.innerHTML;
+      let val = event.target.tagName === 'INPUT' ? event.target.value : event.target.innerHTML;
+      // These are plain-text/numeric fields (time, builders, food, wood, gold,
+      // stone). When edited via a contenteditable div, Chrome leaves a stray
+      // "<br>" (and sometimes a wrapping block) once the cell is cleared, which
+      // would otherwise be saved verbatim (e.g. stone: "<br>"). Strip any markup
+      // so an emptied cell saves "" instead.
+      val = val.replace(/<[^>]*>/g, "").trim();
       steps[index][propertyName] = val;
       stepsCopy[index][propertyName] = val;
 


### PR DESCRIPTION
## Problem

Resource/timing cells (time, builders, food, wood, gold, **stone**) in the build-order editor are edited via `contenteditable` divs. When a cell is cleared, Chrome leaves a stray `<br>` behind (sometimes wrapped in a block element), and `updateStep` saved `event.target.innerHTML` verbatim — so builds got persisted with e.g. `stone: "<br>"`.

The read-only build page renders these fields as **text** (`{{ item.stone }}`), so the literal `<br>` appeared on the page. It was most visible on **stone**, the least-used field, which is the one users most often tab into and clear.

## Fix

- **`updateStep`** (`BuildOrderSectionEditor.vue`): strip markup from the captured value so an emptied cell saves `""` instead of `"<br>"`. `<input>`-based cells (desktop) are unaffected since their `.value` never contains tags.
- **`initializeSections`** (`BuildOrderEditor.vue`): sanitize these fields on load, so builds already stored with `"<br>"` render correctly immediately (and get cleaned permanently on next save). Runs on mount for both the read-only view and the editor.

Both use the same conservative transform (`value.replace(/<[^>]*>/g, "").trim()`) and only touch plain-text/numeric fields — no icon/description fields are affected.

## Testing

- Reproduced by loading a build whose step has `stone: "<br>"` → previously rendered a literal `<br>`; now renders as empty (`–`) with no `<br>` anywhere on the page.
- Verified real numeric values (`"6"`, `"2:40"`) pass through unchanged.
- `npm run build` passes.