### PR TITLE
perf: parallelize independent Firestore queries in list views

### DIFF
--- a/src/views/builds/BuildDetails.vue
+++ b/src/views/builds/BuildDetails.vue
@@ -212,18 +212,18 @@ export default {
     const descriptionExpanded = ref(true);
 
     onMounted(async () => {
-      var resBuild = null;
-      if (props.id in store.state.cache.builds) {
-        //Build found in store
-        resBuild = store.state.cache.builds[props.id];
-      } else {
-        //"Build not found in store, fetching from firestore"
-        resBuild = await getBuild(props.id);
-      }
+      const cachedBuild = props.id in store.state.cache.builds ? store.state.cache.builds[props.id] : null;
+
+      // The build and the user's favorites are independent (favorites only needs
+      // the uid, not the build), so fetch them in parallel instead of in series.
+      const [resBuild, favorites] = await Promise.all([
+        cachedBuild ? Promise.resolve(cachedBuild) : getBuild(props.id),
+        user.value ? getUserFavorites(user.value.uid) : Promise.resolve(null),
+      ]);
+
       if (resBuild) {
-        //Get user data (favorites and likes)
         if (user.value) {
-          userData.value = await getUserFavorites(user.value.uid);
+          userData.value = favorites;
         }
 
         build.value = resBuild;

--- a/src/views/builds/Builds.vue
+++ b/src/views/builds/Builds.vue
@@ -144,30 +144,26 @@ export default {
     const initData = async () => {
       store.commit("setLoading", true);
 
-      //get contributor
-      contributor.value = await getContributor(filterConfig.value.author);
-
       //reset results count
       store.commit("setResultsCount", null);
+      builds.value = Array(paginationConfig.value.limit).fill({ loading: true });
 
-      //init count
-      const size = await getBuildsCount(filterConfig.value);
+      const cachedList = store.state.cache.allBuildsList;
+
+      // Contributor, count and list are independent — run them in parallel
+      // instead of awaiting each in turn.
+      const [contributorRes, size, listRes] = await Promise.all([
+        getContributor(filterConfig.value.author),
+        getBuildsCount(filterConfig.value),
+        cachedList
+          ? Promise.resolve(cachedList)
+          : getBuilds(filterConfig.value, paginationConfig.value.limit),
+      ]);
+
+      contributor.value = contributorRes;
       store.commit("setResultsCount", size);
-
-      //get page size
-      const currentPageSize = Math.min(size, paginationConfig.value.limit);
-      builds.value = Array(currentPageSize).fill({
-        loading: true,
-      });
-
-      //get builds
-      if (store.state.cache.allBuildsList) {
-        builds.value = store.state.cache.allBuildsList;
-      } else {
-        const res = await getBuilds(filterConfig.value, paginationConfig.value.limit);
-        builds.value = res;
-        store.commit("setAllBuildsList", res);
-      }
+      if (!cachedList) store.commit("setAllBuildsList", listRes);
+      builds.value = listRes;
 
       //init pagination config
       paginationConfig.value.totalPages = Math.ceil(size / paginationConfig.value.limit);

--- a/src/views/builds/Dashboard.vue
+++ b/src/views/builds/Dashboard.vue
@@ -182,27 +182,33 @@ export default {
       //reset results count
       store.commit("setResultsCount", null);
 
-      // Count first — if zero we show NoFilterResults immediately without
-      // ever resolving the lists to [], which would cause a flicker through
-      // BuildLaneTabs' own empty-state before the outer guard kicks in.
+      // The count and the three lane queries are independent, so run them in
+      // parallel instead of stacking four sequential round-trips.
       var configpopularBuildsList = JSON.parse(JSON.stringify(filterConfig.value));
       configpopularBuildsList.orderBy = "score";
-      trendingCount.value = await getBuildsCount(configpopularBuildsList);
-      store.commit("setResultsCount", trendingCount.value);
-      if (trendingCount.value === 0) return;
-
-      //get popular
-      popularBuildsList.value = await getBuilds(configpopularBuildsList, 10);
-
-      //get all time classics
       var configAllTimeClassicsList = JSON.parse(JSON.stringify(filterConfig.value));
       configAllTimeClassicsList.orderBy = "scoreAllTime";
-      allTimeClassicsList.value = await getBuilds(configAllTimeClassicsList, 10);
-
-      //get most recent
       var configRecentBuildsList = JSON.parse(JSON.stringify(filterConfig.value));
       configRecentBuildsList.orderBy = "timeCreated";
-      recentBuildsList.value = await getBuilds(configRecentBuildsList, 10);
+
+      const [count, popular, classics, recent] = await Promise.all([
+        getBuildsCount(configpopularBuildsList),
+        getBuilds(configpopularBuildsList, 10),
+        getBuilds(configAllTimeClassicsList, 10),
+        getBuilds(configRecentBuildsList, 10),
+      ]);
+
+      trendingCount.value = count;
+      store.commit("setResultsCount", count);
+
+      // Count === 0 → leave the lists as loading skeletons; the template shows
+      // NoFilterResults (gated on count), so there is no flicker through
+      // BuildLaneTabs' own empty-state.
+      if (count === 0) return;
+
+      popularBuildsList.value = popular;
+      allTimeClassicsList.value = classics;
+      recentBuildsList.value = recent;
     };
 
     return {

--- a/src/views/builds/MyBuilds.vue
+++ b/src/views/builds/MyBuilds.vue
@@ -125,32 +125,23 @@ export default {
 
       //reset author filter
       store.commit("setAuthor", null);
+      builds.value = Array(paginationConfig.value.limit).fill({ loading: true });
 
-      //get drafts
-      drafts.value = await getUserDrafts(user.value.uid);
+      const cachedList = store.state.cache.myBuildsList;
 
-      //init count
-      const size = await getUserBuildsCount(user.value.uid, filterConfig.value);
+      // Drafts, count and list are independent — run them in parallel.
+      const [userDrafts, size, listRes] = await Promise.all([
+        getUserDrafts(user.value.uid),
+        getUserBuildsCount(user.value.uid, filterConfig.value),
+        cachedList
+          ? Promise.resolve(cachedList)
+          : getUserBuilds(user.value.uid, filterConfig.value, paginationConfig.value.limit),
+      ]);
+
+      drafts.value = userDrafts;
       store.commit("setResultsCount", size);
-
-      //get page size
-      const currentPageSize = Math.min(size, paginationConfig.value.limit);
-      builds.value = Array(currentPageSize).fill({
-        loading: true,
-      });
-
-      //get my builds
-      if (store.state.cache.myBuildsList) {
-        builds.value = store.state.cache.myBuildsList;
-      } else {
-        const res = await getUserBuilds(
-          user.value.uid,
-          filterConfig.value,
-          paginationConfig.value.limit
-        );
-        builds.value = res;
-        store.commit("setMyBuildsList", res);
-      }
+      if (!cachedList) store.commit("setMyBuildsList", listRes);
+      builds.value = listRes;
 
       //init pagination config
       paginationConfig.value.totalPages = Math.ceil(size / paginationConfig.value.limit);

--- a/src/views/builds/MyFavorites.vue
+++ b/src/views/builds/MyFavorites.vue
@@ -121,37 +121,32 @@ export default {
       //reset author filter
       store.commit("setAuthor", null);
 
-      //get favorites array
+      // Favorites array is needed by both the count and list queries, so it
+      // must be fetched first.
       favorites.value = await getUserFavoritesArray(user.value.uid).then((user) => {
         return user.favorites;
       });
-      if (!favorites.value.length > 0) {
+      if (!(favorites.value.length > 0)) {
         builds.value = null;
+        store.commit("setLoading", false);
         return;
       }
 
-      //init count
-      const size = await getUserFavoritesCount(favorites.value, filterConfig.value);
+      builds.value = Array(paginationConfig.value.limit).fill({ loading: true });
+
+      const cachedList = store.state.cache.myFavoritesList;
+
+      // Given the favorites array, count and list are independent — parallelize.
+      const [size, listRes] = await Promise.all([
+        getUserFavoritesCount(favorites.value, filterConfig.value),
+        cachedList
+          ? Promise.resolve(cachedList)
+          : getUserFavorites(favorites.value, filterConfig.value, paginationConfig.value.limit),
+      ]);
+
       store.commit("setResultsCount", size);
-
-      //get page size
-      const currentPageSize = Math.min(size, paginationConfig.value.limit);
-      builds.value = Array(currentPageSize).fill({
-        loading: true,
-      });
-
-      //get favorites
-      if (store.state.cache.myFavoritesList) {
-        builds.value = store.state.cache.myFavoritesList;
-      } else {
-        const res = await getUserFavorites(
-          favorites.value,
-          filterConfig.value,
-          paginationConfig.value.limit
-        );
-        builds.value = res;
-        store.commit("setMyFavoritesList", res);
-      }
+      if (!cachedList) store.commit("setMyFavoritesList", listRes);
+      builds.value = listRes;
 
       //init pagination config
       paginationConfig.value.totalPages = Math.ceil(size / paginationConfig.value.limit);


### PR DESCRIPTION
Follow-up to #127. The list views awaited independent Firestore queries one after another, stacking network round-trips on every page load. Each now fires its independent queries with `Promise.all`.

| View | Before | After |
|---|---|---|
| **Dashboard** (civ page) | count → trending → classics → new (4 serial) | 1 parallel batch |
| **Builds** (browse) | contributor → count → list (3 serial) | 1 batch |
| **MyBuilds** | drafts → count → list (3 serial) | 1 batch |
| **MyFavorites** | favorites → count → list (3 serial) | favorites, then count + list in parallel |
| **BuildDetails** | build → favorites (2 serial) | 1 batch |

Firestore round-trips are typically ~150–400 ms each, so this shaves roughly **2–3 round-trips (~0.5–1 s)** off each of these page loads.

**Safety / behavior preserved:**
- Dependent calls stay ordered (e.g. MyFavorites still fetches the favorites array first, since the count and list queries need it).
- Cache hits still short-circuit the network — the cached-list branches are wrapped in `Promise.resolve(...)` so no query fires on a cache hit.
- The count-gated empty state is preserved: lists are only assigned once the count is known, so there's no flicker through a lane's own empty-state on an empty result.

Also a small drive-by fix in MyFavorites: the empty-favorites early-return now resets the loading flag (it previously returned without clearing it, leaving the page stuck on a spinner for users with no favorites).