### PR TITLE
perf(dashboard): render lanes progressively, fetch preview count only when dirty

### DIFF
--- a/src/components/filter/FilterConfig.vue
+++ b/src/components/filter/FilterConfig.vue
@@ -229,7 +229,6 @@
     <FilterApplyBar
       :isDirty="isDirty"
       :appliedCount="count"
-      :previewEnabled="previewEnabled"
       :previewCount="previewCount"
       :previewLoading="previewLoading"
       @apply="handleApply"
@@ -279,9 +278,12 @@ export default {
     const { draft, dirtyFields, dirtyCount, isDirty, resetField, applyDraft } =
       useDraftFilterConfig();
 
-    const previewEnabled = ref(true);
+    // Only fetch the preview count while the draft differs from the applied
+    // config — the apply bar (its only consumer) is hidden otherwise. This
+    // also keeps store-driven draft re-syncs (mount, route navigation) from
+    // firing a redundant count aggregation per FilterConfig instance.
     const { previewCount, previewLoading } = useFilterCountPreview(draft, {
-      enabled: previewEnabled,
+      enabled: isDirty,
       countFn: props.countFn,
     });
 
@@ -366,7 +368,6 @@ export default {
       handleApply,
       showReset,
       onRemoveChip,
-      previewEnabled,
       previewCount,
       previewLoading,
       smAndDown,

--- a/src/components/home/BuildLaneTabs.vue
+++ b/src/components/home/BuildLaneTabs.vue
@@ -59,8 +59,8 @@
         </v-alert>
         <template v-else>
           <router-link
-            v-for="item in laneList(lane.value)"
-            :key="item.id ?? item.loading"
+            v-for="(item, i) in laneList(lane.value)"
+            :key="item.id ?? i"
             style="text-decoration: none"
             :to="item.loading ? { name: 'Home' } : { name: 'BuildDetails', params: { id: item.id } }"
           >

--- a/src/views/builds/Dashboard.vue
+++ b/src/views/builds/Dashboard.vue
@@ -172,7 +172,12 @@ export default {
       }
     });
 
+    // Monotonic token identifying the latest initData run, so responses from
+    // a superseded run never overwrite the current one.
+    let initDataRun = 0;
+
     const initData = async () => {
+      const runId = ++initDataRun;
       allTimeClassicsList.value = Array(10).fill({ loading: true });
       popularBuildsList.value = Array(10).fill({ loading: true });
       recentBuildsList.value = Array(10).fill({ loading: true });
@@ -191,12 +196,34 @@ export default {
       var configRecentBuildsList = JSON.parse(JSON.stringify(filterConfig.value));
       configRecentBuildsList.orderBy = "timeCreated";
 
+      const countPromise = getBuildsCount(configpopularBuildsList);
+      const lanes = [
+        { promise: getBuilds(configpopularBuildsList, 10), target: popularBuildsList },
+        { promise: getBuilds(configAllTimeClassicsList, 10), target: allTimeClassicsList },
+        { promise: getBuilds(configRecentBuildsList, 10), target: recentBuildsList },
+      ];
+
+      // The count aggregation is consistently the slowest of the four queries,
+      // so each lane renders as soon as its own query resolves instead of
+      // waiting for the whole batch. An empty lane result stays a skeleton:
+      // only the count decides between "no results for this filter"
+      // (NoFilterResults) and data, avoiding a flash of BuildLaneTabs' own
+      // empty state.
+      for (const { promise, target } of lanes) {
+        promise
+          .then((builds) => {
+            if (runId === initDataRun && builds.length > 0) target.value = builds;
+          })
+          .catch(() => {}); // rejections surface via the await below
+      }
+
       const [count, popular, classics, recent] = await Promise.all([
-        getBuildsCount(configpopularBuildsList),
-        getBuilds(configpopularBuildsList, 10),
-        getBuilds(configAllTimeClassicsList, 10),
-        getBuilds(configRecentBuildsList, 10),
+        countPromise,
+        ...lanes.map((lane) => lane.promise),
       ]);
+
+      // A newer initData run (filter change mid-flight) supersedes this one.
+      if (runId !== initDataRun) return;
 
       trendingCount.value = count;
       store.commit("setResultsCount", count);


### PR DESCRIPTION
Follow-up to #128 — the dashboard still felt slow, so I profiled the network waterfall on a production load of `/dashboard?civ=BYZ`. Two findings, plus a small warning fix picked up along the way.

## What the network tab showed

| Time | Request | Duration |
|---|---|---|
| ~750ms | `runAggregationQuery` (count from `initData`) | **~2.1s** |
| ~780ms | `Listen` channel opens; the 3 lane queries ride on it | lists arrive ~1.2–2.3s |
| ~1.2s | `runAggregationQuery` × 2 — redundant duplicates | 1.7s / 2.2s |

- The **count aggregation is consistently the slowest** of the four parallel queries, and `Promise.all` held the three lists (already in the browser at ~1.2s) hostage to it — skeletons sat on screen an extra ~1s holding data that had already arrived.
- **Three count aggregations fired per page view** where one is needed. The extra two come from the filter panel: both the mobile and desktop `FilterConfig` instances mount (they're CSS-hidden via `hidden-md-and-up`/`hidden-sm-and-down`, not `v-if`-gated), and the store-driven draft re-sync on mount trips `useFilterCountPreview`'s deep watch — firing a preview count for a draft the user never touched.

## Changes

1. **Dashboard: progressive lane rendering.** Each lane renders as soon as its own query resolves; the count no longer gates them. It still decides the one thing it's needed for — the `NoFilterResults` empty state: empty lane results stay skeletons until the count settles, so there's no flash of `BuildLaneTabs`' own empty state, same as before. Also added a monotonic run token so a superseded `initData` (filter change mid-flight) can't overwrite newer results — that race predates this PR; progressive assignment just made it worth closing properly.

2. **FilterConfig: gate the preview count on `isDirty`.** The apply bar (the preview count's only consumer) is hidden when the draft is clean, so those mount-time fetches were pure waste. Gating on dirty also means a never-edited hidden instance can never fire — this removes 2 aggregation reads per view on **every** list view (Dashboard, Builds, MyBuilds, MyFavorites), which should be a welcome read-cost saving. Editing a filter still previews exactly as before (verified: "Show N results" appears on edit, apply works).

3. **BuildLaneTabs: skeleton row keys.** Skeleton items are `{ loading: true }`, so `:key="item.id ?? item.loading"` gave all ten rows the key `true` — Vue logged a duplicate-key warning on every lane update. Keyed by index fallback now.

## Impact

Lanes now appear when the list data lands (~1.2s on my connection instead of ~2.5–3.5s waiting on the count), and each dashboard visit costs 1 count aggregation instead of 3. The remaining floor is the WebChannel handshake + RTT to Firestore's region, which client code can't remove.

## Verified

- `npm run check:icons` ✓, production build ✓
- Manually exercised the dashboard: initial load, filter edit → preview count, apply → reload, reset — no console errors, duplicate-key warning gone.