### PR TITLE
refactor(dashboard): drop dead code left by #129

### DIFF
--- a/src/components/filter/FilterApplyBar.vue
+++ b/src/components/filter/FilterApplyBar.vue
@@ -9,7 +9,7 @@
       @click="$emit('apply')"
     >
       <template v-if="previewLoading">Counting…</template>
-      <template v-else-if="previewEnabled && previewCount !== null">
+      <template v-else-if="previewCount !== null">
         Show {{ previewCount }} {{ previewCount === 1 ? "result" : "results" }}
       </template>
       <template v-else-if="appliedCount !== null">
@@ -32,7 +32,6 @@ export default {
   props: {
     isDirty:        { type: Boolean, default: false },
     appliedCount:   { type: Number,  default: null },
-    previewEnabled: { type: Boolean, default: true },
     previewCount:   { type: Number,  default: null },
     previewLoading: { type: Boolean, default: false },
   },

--- a/src/views/builds/Dashboard.vue
+++ b/src/views/builds/Dashboard.vue
@@ -217,7 +217,10 @@ export default {
           .catch(() => {}); // rejections surface via the await below
       }
 
-      const [count, popular, classics, recent] = await Promise.all([
+      // Still await the lanes so a mid-flight supersede is detected and any
+      // rejection surfaces; the progressive handlers above already assigned
+      // their results, so only the count value is needed here.
+      const [count] = await Promise.all([
         countPromise,
         ...lanes.map((lane) => lane.promise),
       ]);
@@ -225,17 +228,11 @@ export default {
       // A newer initData run (filter change mid-flight) supersedes this one.
       if (runId !== initDataRun) return;
 
+      // Commit the count: >0 keeps the progressively-assigned lanes on screen;
+      // ===0 leaves the lanes as skeletons and flips the template to
+      // NoFilterResults (gated on count), so there is no empty-state flicker.
       trendingCount.value = count;
       store.commit("setResultsCount", count);
-
-      // Count === 0 → leave the lists as loading skeletons; the template shows
-      // NoFilterResults (gated on count), so there is no flicker through
-      // BuildLaneTabs' own empty-state.
-      if (count === 0) return;
-
-      popularBuildsList.value = popular;
-      allTimeClassicsList.value = classics;
-      recentBuildsList.value = recent;
     };
 
     return {


### PR DESCRIPTION
Cosmetic follow-ups to #129 — no behavior change, build + `check:icons` green.

1. **`FilterApplyBar`: remove the `previewEnabled` prop.** Once #129 gated the preview count on `isDirty`, `FilterConfig` stopped passing `previewEnabled`, so it always fell back to its `true` default — the `previewEnabled &&` guard in the button template was permanently on. Dropped the prop and simplified the guard.

2. **`Dashboard.initData`: drop the redundant post-`await` list assignments.** #129's progressive `.then` handlers already assign each lane as it resolves. All three lanes share one filter/count (they differ only in `orderBy`), so a lane can't be empty while `count > 0` — the post-`await` assignments could never do anything the handlers hadn't. We still `await` the lane promises to detect a mid-flight supersede and surface rejections; only the `count` value is used now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)